### PR TITLE
add vuex store and mobile nav menu

### DIFF
--- a/components/MobileNavigationMenu.vue
+++ b/components/MobileNavigationMenu.vue
@@ -1,0 +1,37 @@
+<template>
+  <div class="mobile-nav-menu">
+    <nuxt-link to="/" v-on:click.native="closeMobileNav" class="mobile-nav-item">Home</nuxt-link>
+    <nuxt-link to="/menu" v-on:click.native="closeMobileNav" class="mobile-nav-item">Menu</nuxt-link>
+    <nuxt-link to="/contact" v-on:click.native="closeMobileNav" class="mobile-nav-item">Contact</nuxt-link>
+  </div>
+</template>
+
+<script>
+import { mapMutations } from 'vuex'
+
+export default {
+  name: 'MobileNavigationMenu',
+  methods: {
+    ...mapMutations(['closeMobileNav'])
+  }
+}
+</script>
+
+<style>
+.mobile-nav-item {
+  font-size: 22px;
+  font-weight: 600;
+  padding: 20px;
+  color: #ffffff;
+  border-bottom: 2px solid #1E2025;
+  background-color: #444653;
+}
+
+.mobile-nav-menu {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  z-index: 999;
+  background-color: #686761;
+}
+</style>

--- a/components/MobileTopBar.vue
+++ b/components/MobileTopBar.vue
@@ -1,15 +1,27 @@
 <template>
   <div class="top-bar">
-    <img class="logo" src="/pizzaroma-logo.svg"/>
+    <nuxt-link to="/">
+      <img class="logo" src="/pizzaroma-logo.svg"/>
+    </nuxt-link>
     <div class="top-bar-right">
-      <font-awesome-icon icon="bars" />
+      <font-awesome-icon v-if="!showMobileNav" icon="bars" v-on:click="handleShowNav"/>
+      <font-awesome-icon v-else icon="times" v-on:click="handleShowNav"/>
     </div>
   </div>
 </template>
 
 <script>
+import { mapMutations, mapActions, mapState } from 'vuex'
+
 export default {
-  name: 'TopBar'
+  name: 'TopBar',
+  computed: {
+    ...mapState(['showMobileNav'])
+  },
+  methods: {
+    ...mapMutations(['openMobileNav', 'closeMobileNav']),
+    ...mapActions(['handleShowNav'])
+  }
 }
 </script>
 
@@ -29,10 +41,6 @@ export default {
   color: #ffffff;
 }
 
-.nav-element:hover {
-  background-color: #22242c;
-}
-
 .logo {
   padding: 5px;
   margin: 5px;
@@ -42,11 +50,10 @@ export default {
   display: flex;
   height: 75px;
   width: 100%;
-  background-color: #191A21;
+  background-color: #1e1f25;
   flex-direction: row;
   justify-content: space-between;
   align-items: center;
-  opacity: 0.99;
 }
 
 .top-bar-right {

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -2,17 +2,25 @@
   <div class="page">
     <TopBar class="is-hidden-touch"/>
     <MobileTopBar class="is-hidden-desktop"/>
-    <Nuxt class="content" />
+    <div v-if="showMobileNav">
+      <MobileNavigationMenu />
+    </div>
+    <div v-else>
+      <Nuxt class="content" />
+    </div>
     <BottomBar />
   </div>
 </template>
 
 <script>
+import { mapState } from 'vuex'
 import TopBar from '../components/TopBar'
 import BottomBar from '../components/BottomBar'
+import MobileNavigationMenu from '../components/MobileNavigationMenu'
 
 export default {
-  components: { TopBar, BottomBar }
+  components: { TopBar, BottomBar, MobileNavigationMenu },
+  computed: mapState(['showMobileNav'])
 }
 </script>
 
@@ -32,6 +40,7 @@ export default {
 .content {
   min-height: 100vh;
   margin-bottom: 0px !important;
+  position: relative;
 }
 
 html {

--- a/store/index.js
+++ b/store/index.js
@@ -1,0 +1,18 @@
+export const state = () => ({
+  showMobileNav: false
+})
+
+export const mutations = {
+  openMobileNav(state) {
+    state.showMobileNav = true
+  },
+  closeMobileNav(state) {
+    state.showMobileNav = false
+  }
+}
+
+export const actions = {
+  handleShowNav({ state, commit }) {
+    state.showMobileNav ? commit('closeMobileNav') : commit('openMobileNav')
+  }
+}


### PR DESCRIPTION
This PR adds mobile navigation. This PR also adds a vuex root store for managing the state of the navigation menu.

Open:
![image](https://user-images.githubusercontent.com/41226602/93164046-9a4efc00-f6e6-11ea-8690-8276a4063a62.png)

Closed:
![image](https://user-images.githubusercontent.com/41226602/93164096-b488da00-f6e6-11ea-864f-6aabb45e93ec.png)
